### PR TITLE
[WPI]自動更新機能

### DIFF
--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,10 @@
+class Api::MessagesController < ApplicationController
+  def index
+    # ルーティングでの設定によりparamsの中にgroup_idというキーでグループのidが入るので、これを元にDBからグループを取得する
+    group = Group.find(params[:group_id])
+    # ajaxで送られてくる最後のメッセージのid番号を変数に代入
+    last_message_id = params[:id].to_i
+    # 取得したグループでのメッセージ達から、idがlast_messge_idよりも新しい(大きい)メッセージ達のみを取得
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image
+  json.created_at message.created_at
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,4 @@
+json.(@message, :content, :image)
 json.id      @message.id
-json.content @message.content 
 json.date    @message.created_at.strftime("%Y/%m/%d %H:%M")
 json.user_name @message.user.name
-json.image   @message.image.url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,9 @@ Rails.application.routes.draw do
   resource :user, only: [:edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
[What]
chat-spaceで別のユーザーがチャットを投稿した場合、手動でリロードせずともmessage画面に
投稿したメッセージが反映される機能を追加実装する。
・カスタムデータ属性の取得
・APIフォルダにmessage_controllerを新たに作り、名前空間を用いて既存のmessage_controllerと
　区別する。
・ルーティングとjson形式でデータが返送されるように設定。
・数秒ごとにリクエストされ、メッセージ分だけスクロール出来るようにする
・メッセージの一覧ページでのみ自動更新が行われる。
[why]
自動でメッセージが反映されないままだと、チャットツールとして実用性がないため。